### PR TITLE
feat: widen analyzer constraint for Flutter 3.32+ compatibility

### DIFF
--- a/packages/rfw_gen_builder/pubspec.yaml
+++ b/packages/rfw_gen_builder/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  analyzer: ^9.0.0
+  analyzer: ">=7.4.5 <10.0.0"
   build: ^4.0.0
   rfw: ^1.0.0
   yaml: ^3.1.0


### PR DESCRIPTION
## Summary
- Change analyzer from `^9.0.0` to `>=7.4.5 <10.0.0`
- Enables rfw_gen_builder to work with Flutter 3.32+ (analyzer 7.x) through 3.41+ (analyzer 9.x)
- No API incompatibilities — only uses stable AST node types and parseString()

## Test plan
- [x] 500 tests pass locally
- [ ] CI passes