### PR TITLE
release: v0.2.0

### DIFF
--- a/packages/rfw_gen/CHANGELOG.md
+++ b/packages/rfw_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Add `column` field to `RfwGenIssue` for precise error location reporting
+
 ## 0.1.0
 
 - Initial release

--- a/packages/rfw_gen/pubspec.yaml
+++ b/packages/rfw_gen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen
 description: Annotations and runtime helpers for converting Flutter Widget code to RFW (Remote Flutter Widgets) format.
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:

--- a/packages/rfw_gen_builder/CHANGELOG.md
+++ b/packages/rfw_gen_builder/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.2.0
+
+- **Breaking**: `RfwConverter.convertFromSource()` and `convertFromAst()` now return `ConvertResult` instead of `String`
+- Add `IssueCollector` for accumulating conversion errors with line:column info
+- Replace silent `developer.log` with build-visible `log.warning`/`log.severe`
+- Add suggestion messages for common unsupported patterns (ternary → RfwSwitch, etc.)
+- Add `parseLibraryFile()` validation step for generated rfwtxt
+- Fix missing offset in 7 `UnsupportedExpressionError` throw sites
+
 ## 0.1.0
 
 - Initial release

--- a/packages/rfw_gen_builder/pubspec.yaml
+++ b/packages/rfw_gen_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen_builder
 description: build_runner code generator for rfw_gen. Converts @RfwWidget-annotated Flutter functions to RFW format.
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:


### PR DESCRIPTION
## Summary
- 버전 0.1.0 → 0.2.0
- CHANGELOG 업데이트

## Changes in 0.2.0
- **rfw_gen**: `RfwGenIssue`에 `column` 필드 추가
- **rfw_gen_builder**: `IssueCollector`, `ConvertResult` 추가, 에러 보고 개선
- **Breaking**: `RfwConverter` 반환값 `String` → `ConvertResult`

## Test plan
- [x] 전체 테스트 통과