### PR TITLE
release: v0.2.1

### DIFF
--- a/packages/rfw_gen/CHANGELOG.md
+++ b/packages/rfw_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- No changes to rfw_gen (version bump to match rfw_gen_builder)
+
 ## 0.2.0
 
 - Add `column` field to `RfwGenIssue` for precise error location reporting

--- a/packages/rfw_gen/pubspec.yaml
+++ b/packages/rfw_gen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen
 description: Annotations and runtime helpers for converting Flutter Widget code to RFW (Remote Flutter Widgets) format.
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:

--- a/packages/rfw_gen_builder/CHANGELOG.md
+++ b/packages/rfw_gen_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- Widen `analyzer` constraint from `^9.0.0` to `>=7.4.5 <10.0.0` for Flutter 3.32+ compatibility
+
 ## 0.2.0
 
 - **Breaking**: `RfwConverter.convertFromSource()` and `convertFromAst()` now return `ConvertResult` instead of `String`

--- a/packages/rfw_gen_builder/pubspec.yaml
+++ b/packages/rfw_gen_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen_builder
 description: build_runner code generator for rfw_gen. Converts @RfwWidget-annotated Flutter functions to RFW format.
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:


### PR DESCRIPTION
## Summary
- Widen `analyzer` constraint from `^9.0.0` to `>=7.4.5 <10.0.0`
- Enables rfw_gen_builder with Flutter 3.32+ (3o3_flutter compatibility)
- Version bump: 0.2.0 → 0.2.1 (both packages)

## Test plan
- [ ] CI passes
- [ ] `dart pub publish --dry-run` passes