### PR TITLE
fix(ci): use flutter-action in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,22 +12,27 @@ jobs:
       id-token: write # Required for pub.dev OIDC authentication
     steps:
       - uses: actions/checkout@v4
-      - uses: dart-lang/setup-dart@v1
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
 
       - name: Resolve workspace dependencies
-        run: dart pub get
+        run: flutter pub get
 
       - name: Publish rfw_gen
         run: dart pub publish --directory packages/rfw_gen --force
+        continue-on-error: true
 
       - name: Wait for pub.dev indexing
         run: sleep 60
 
       - name: Publish rfw_gen_builder
         run: dart pub publish --directory packages/rfw_gen_builder --force
+        continue-on-error: true
 
       - name: Wait for pub.dev indexing
         run: sleep 60
 
       - name: Publish rfw_gen_mcp
         run: dart pub publish --directory packages/rfw_gen_mcp --force
+        continue-on-error: true


### PR DESCRIPTION
## Summary

- publish.yml에서 `dart-lang/setup-dart` → `subosito/flutter-action` 변경
  - `rfw` 패키지가 Flutter SDK에 의존하여 `dart pub get` 실패
- 각 publish 스텝에 `continue-on-error: true` 추가
  - 이미 배포된 버전 재배포 시 에러가 나도 다음 패키지 배포 계속 진행

## Test plan

- [x] v0.2.1 태그에서 실패한 원인 확인 (Flutter SDK 누락)
- [ ] CI 통과 확인
- [ ] 머지 후 태그 재push로 자동 배포 검증