### PR TITLE
fix(ci): add OIDC token setup for pub.dev publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
       id-token: write # Required for pub.dev OIDC authentication
     steps:
       - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
       - uses: subosito/flutter-action@v2
         with:
           channel: stable


### PR DESCRIPTION
## Summary

- `dart-lang/setup-dart@v1` 추가: OIDC `PUB_TOKEN` 설정 (pub.dev 자동 인증)
- `subosito/flutter-action`만으로는 OIDC 토큰이 설정되지 않아 OAuth 수동 인증을 요구하는 문제 수정

## Test plan

- [ ] CI 통과 확인
- [ ] 머지 후 태그 재push → 자동 배포 확인