### PR TITLE
ci: auto-create GitHub Release on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Required for pub.dev OIDC authentication
+      contents: write # Required for creating GitHub Releases
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
@@ -37,3 +38,8 @@ jobs:
       - name: Publish rfw_gen_mcp
         run: dart pub publish --directory packages/rfw_gen_mcp --force
         continue-on-error: true
+
+      - name: Create GitHub Release
+        run: gh release create ${{ github.ref_name }} --generate-notes --title "${{ github.ref_name }}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- publish.yml 마지막에 GitHub Release 자동 생성 스텝 추가
- `--generate-notes`로 마지막 태그 이후 머지된 PR 목록을 자동 수집
- `contents: write` 권한 추가

## Test plan

- [ ] CI 통과 확인
- [ ] 다음 릴리스 태그 push 시 GitHub Release 자동 생성 확인