### PR TITLE
ci: show tag name in publish workflow run title

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 name: Publish to pub.dev
+run-name: "Publish ${{ github.ref_name }}"
 
 on:
   push:


### PR DESCRIPTION
워크플로우 목록에 `Publish v0.2.3` 형태로 표시되도록 run-name 추가