### PR TITLE
feat(mcp): auto-load custom widgets from rfw_gen.yaml

### DIFF
--- a/packages/rfw_gen/CHANGELOG.md
+++ b/packages/rfw_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- No changes (version bump to match rfw_gen_mcp)
+
 ## 0.2.2
 
 - No changes (version bump to match rfw_gen_mcp)

--- a/packages/rfw_gen/pubspec.yaml
+++ b/packages/rfw_gen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen
 description: Annotations and runtime helpers for converting Flutter Widget code to RFW (Remote Flutter Widgets) format.
-version: 0.2.2
+version: 0.3.0
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:

--- a/packages/rfw_gen_builder/CHANGELOG.md
+++ b/packages/rfw_gen_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- No changes (version bump to match rfw_gen_mcp)
+
 ## 0.2.2
 
 - No changes (version bump to match rfw_gen_mcp)

--- a/packages/rfw_gen_builder/pubspec.yaml
+++ b/packages/rfw_gen_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen_builder
 description: build_runner code generator for rfw_gen. Converts @RfwWidget-annotated Flutter functions to RFW format.
-version: 0.2.2
+version: 0.3.0
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:
@@ -19,7 +19,7 @@ dependencies:
   build: ^4.0.0
   rfw: ^1.0.0
   yaml: ^3.1.0
-  rfw_gen: ^0.2.2
+  rfw_gen: ^0.3.0
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/packages/rfw_gen_mcp/CHANGELOG.md
+++ b/packages/rfw_gen_mcp/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Auto-load `rfw_gen.yaml` from cwd to register custom widgets in MCP server
+
 ## 0.2.2
 
 - Support `dart pub global activate` for use in external projects

--- a/packages/rfw_gen_mcp/lib/src/server.dart
+++ b/packages/rfw_gen_mcp/lib/src/server.dart
@@ -21,7 +21,7 @@ import 'tools/validate_rfwtxt.dart';
 /// if present, registering custom widgets into the registry.
 Future<void> runRfwGenMcpServer() async {
   final server = McpServer(
-    const Implementation(name: 'rfw_gen', version: '0.2.2'),
+    const Implementation(name: 'rfw_gen', version: '0.3.0'),
     options: const McpServerOptions(
       capabilities: ServerCapabilities(
         tools: ServerCapabilitiesTools(),

--- a/packages/rfw_gen_mcp/pubspec.yaml
+++ b/packages/rfw_gen_mcp/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen_mcp
 description: MCP server exposing rfw_gen widget registry, code conversion, and rfwtxt validation.
-version: 0.2.2
+version: 0.3.0
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:
@@ -20,8 +20,8 @@ resolution: workspace
 dependencies:
   mcp_dart: ^1.3.0
   rfw: ^1.0.0
-  rfw_gen: ^0.2.2
-  rfw_gen_builder: ^0.2.2
+  rfw_gen: ^0.3.0
+  rfw_gen_builder: ^0.3.0
   yaml: ^3.1.0
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- MCP 서버 시작 시 cwd의 `rfw_gen.yaml`을 자동으로 읽어 커스텀 위젯을 `WidgetRegistry`에 등록
- 기존 `WidgetRegistry.registerFromConfig()`를 활용, 파일 없거나 파싱 에러 시 silent ignore
- 세 패키지 모두 `0.2.2` → `0.3.0` 버전 범프

## Background
`convert_to_rfwtxt`로 커스텀 위젯(예: MystiqueText) 포함 Dart 코드를 변환하면 `MystiqueText is not registered` 에러 발생. `rfw_gen_builder`에 이미 구현된 `registerFromConfig()`를 MCP 서버에서도 활용하도록 연결.

## Test plan
- [ ] `rfw_gen.yaml` 없는 환경에서 MCP 서버 정상 시작 확인 (기존 동작 유지)
- [ ] `rfw_gen.yaml`에 커스텀 위젯 정의 후 `list_widgets`로 등록 확인
- [ ] 커스텀 위젯 포함 Dart 코드 `convert_to_rfwtxt` 변환 성공 확인