### PR TITLE
release: 0.4.1

### DIFF
--- a/packages/rfw_gen/CHANGELOG.md
+++ b/packages/rfw_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+- No changes (version bump to match rfw_gen_builder)
+
 ## 0.4.0
 
 - **Breaking**: Remove `rfw_gen.yaml` custom widget configuration

--- a/packages/rfw_gen/pubspec.yaml
+++ b/packages/rfw_gen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen
 description: Annotations and runtime helpers for converting Flutter Widget code to RFW (Remote Flutter Widgets) format.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:

--- a/packages/rfw_gen_builder/CHANGELOG.md
+++ b/packages/rfw_gen_builder/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.1
+
+- Fix: use `show` directive in generated `.rfw_library.dart` imports to prevent name conflicts with Flutter built-in widgets (#23)
+- Fix: improve error message when `DataRef`/`RfwConcat`/`StateRef` used as a widget (#24)
+- Fix: clarify "no custom widgets found" message in empty `.rfw_library.dart` (#25)
+
 ## 0.4.0
 
 - **Breaking**: Remove `rfw_gen.yaml` support and `yaml` dependency

--- a/packages/rfw_gen_builder/pubspec.yaml
+++ b/packages/rfw_gen_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen_builder
 description: build_runner code generator for rfw_gen. Converts @RfwWidget-annotated Flutter functions to RFW format.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:

--- a/packages/rfw_gen_mcp/CHANGELOG.md
+++ b/packages/rfw_gen_mcp/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+- No changes (version bump to match rfw_gen_builder)
+
 ## 0.4.0
 
 - **Breaking**: Read `.rfw_meta.json` instead of `rfw_gen.yaml` for custom widget metadata

--- a/packages/rfw_gen_mcp/pubspec.yaml
+++ b/packages/rfw_gen_mcp/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen_mcp
 description: MCP server exposing rfw_gen widget registry, code conversion, and rfwtxt validation.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:

--- a/packages/rfw_preview/CHANGELOG.md
+++ b/packages/rfw_preview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+- No changes (version bump to match rfw_gen_builder)
+
 ## 0.4.0
 
 - Initial release (version aligned with rfw_gen ecosystem)

--- a/packages/rfw_preview/pubspec.yaml
+++ b/packages/rfw_preview/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_preview
 description: Dev preview widget for rfw_gen. Renders generated rfwtxt with automatic Runtime setup and custom widget support.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 


### PR DESCRIPTION
## Changes (rfw_gen_builder)

- Fix: `show` directive in generated `.rfw_library.dart` imports (#23)
- Fix: better error message when DataRef/RfwConcat used as widget (#24)
- Fix: clarify empty `.rfw_library.dart` message (#25)
- Docs: RFW-only widget guide (#26)

## Version bumps

All 4 packages: 0.4.0 → 0.4.1