### PR TITLE
fix: handle Icons.xxx and double.infinity in expression converter

### DIFF
--- a/packages/rfw_gen_builder/lib/src/expression_converter.dart
+++ b/packages/rfw_gen_builder/lib/src/expression_converter.dart
@@ -540,6 +540,31 @@ class ExpressionConverter {
       return _convertRfwIcon(identifier, offset: expr.offset);
     }
 
+    // Icons.xxx → auto-convert via RfwIcon lookup
+    if (prefix == 'Icons') {
+      final codepoint = RfwIcon.lookup(identifier);
+      if (codepoint != null) {
+        return IrMapValue({
+          'icon': IrIntValue(codepoint),
+          'fontFamily': IrStringValue('MaterialIcons'),
+        });
+      }
+      throw UnsupportedExpressionError(
+        'Icons.$identifier is not mapped in RfwIcon. '
+        'Use RfwIcon.$identifier instead, or add it to RfwIcon if missing.',
+        offset: expr.offset,
+      );
+    }
+
+    // double.infinity is not supported in RFW
+    if (prefix == 'double' && identifier == 'infinity') {
+      throw UnsupportedExpressionError(
+        'double.infinity is not supported in RFW. '
+        'Use SizedBoxExpand to fill available space, or set a fixed size.',
+        offset: expr.offset,
+      );
+    }
+
     if (prefix == 'Alignment') {
       return _convertAlignmentConstant(identifier, offset: expr.offset);
     }

--- a/packages/rfw_gen_builder/test/expression_converter_test.dart
+++ b/packages/rfw_gen_builder/test/expression_converter_test.dart
@@ -574,6 +574,59 @@ void main() {
     });
   });
 
+  group('Icons prefix (auto-convert to RfwIcon)', () {
+    test('converts Icons.home to iconData map', () {
+      final expr = parseExpression('Icons.home');
+      final result = converter.convert(expr);
+      expect(result, isA<IrMapValue>());
+      final map = result as IrMapValue;
+      expect(map.entries['icon'], isA<IrIntValue>());
+      expect(map.entries['fontFamily'], isA<IrStringValue>());
+      expect((map.entries['fontFamily'] as IrStringValue).value,
+          equals('MaterialIcons'));
+    });
+
+    test('converts Icons.star to iconData map', () {
+      final expr = parseExpression('Icons.star');
+      final result = converter.convert(expr);
+      expect(result, isA<IrMapValue>());
+      final map = result as IrMapValue;
+      expect(map.entries['icon'], isA<IrIntValue>());
+    });
+
+    test('throws for unmapped Icons with helpful message', () {
+      final expr = parseExpression('Icons.nonExistentIcon');
+      expect(
+        () => converter.convert(expr),
+        throwsA(
+          allOf(
+            isA<UnsupportedExpressionError>(),
+            predicate<UnsupportedExpressionError>(
+              (e) => e.message.contains('RfwIcon'),
+            ),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('double.infinity', () {
+    test('throws with helpful message suggesting SizedBoxExpand', () {
+      final expr = parseExpression('double.infinity');
+      expect(
+        () => converter.convert(expr),
+        throwsA(
+          allOf(
+            isA<UnsupportedExpressionError>(),
+            predicate<UnsupportedExpressionError>(
+              (e) => e.message.contains('SizedBoxExpand'),
+            ),
+          ),
+        ),
+      );
+    });
+  });
+
   group('Handler conversion', () {
     test('converts RfwHandler.setState to IrSetStateValue', () {
       final expr = parseExpression("RfwHandler.setState('pressed', true)");


### PR DESCRIPTION
## Summary
- `Icons.xxx` (e.g. `Icons.star`) now auto-converts to RfwIcon iconData map via codepoint lookup
- Unmapped `Icons` throw clear error with guidance to use `RfwIcon` instead
- `double.infinity` throws clear error suggesting `SizedBoxExpand` alternative

## Test plan
- [x] `Icons.home` converts to iconData map with codepoint and MaterialIcons
- [x] `Icons.star` converts correctly
- [x] Unknown `Icons.nonExistentIcon` throws with helpful message mentioning RfwIcon
- [x] `double.infinity` throws with helpful message mentioning SizedBoxExpand
- [x] All 155 expression converter tests pass
- [x] `dart analyze` clean

Fixes #29, Fixes #30