### PR TITLE
fix: improve handler error message and document RfwSwitch limitation

### DIFF
--- a/packages/rfw_gen/README.md
+++ b/packages/rfw_gen/README.md
@@ -223,6 +223,33 @@ For each `.dart` file containing `@RfwWidget` functions, the generator produces:
 - `@RfwWidget` must be applied to top-level functions only.
 - Only the 65 built-in widgets (core + material) are supported out of the box.
   Other widgets are auto-detected and require their source to be importable.
+- `RfwSwitchValue` / `RfwSwitch` **cannot be used in handler positions**
+  (e.g., `onTap`, `onPressed`). This is an RFW runtime limitation — handlers
+  only support `setState`, `setStateFromArg`, and `event`. To conditionally
+  switch behavior, use `RfwSwitch` to swap entire widgets:
+
+  ```dart
+  // ❌ This does NOT work:
+  onPressed: RfwSwitchValue(value: StateRef('mode'), cases: {
+    true: RfwHandler.event('pause', {}),
+    false: RfwHandler.event('start', {}),
+  })
+
+  // ✅ Use RfwSwitch to swap widgets instead:
+  RfwSwitch(
+    value: StateRef('mode'),
+    cases: {
+      true: ElevatedButton(
+        onPressed: RfwHandler.event('pause', {}),
+        child: Text('Pause'),
+      ),
+      false: ElevatedButton(
+        onPressed: RfwHandler.event('start', {}),
+        child: Text('Start'),
+      ),
+    },
+  )
+  ```
 
 ## Pre-1.0 Note
 

--- a/packages/rfw_gen_builder/lib/src/expression_converter.dart
+++ b/packages/rfw_gen_builder/lib/src/expression_converter.dart
@@ -1110,7 +1110,11 @@ class ExpressionConverter {
     }
 
     throw UnsupportedExpressionError(
-      'Unknown handler expression: $methodName',
+      'Unsupported handler expression: $methodName. '
+      'RFW handlers only support RfwHandler.setState, '
+      'RfwHandler.setStateFromArg, and RfwHandler.event. '
+      'RfwSwitchValue/RfwSwitch cannot be used in handler positions — '
+      'use RfwSwitch to swap entire widgets with different handlers instead.',
       offset: expr.offset,
     );
   }


### PR DESCRIPTION
## Summary
- Improve error message when `RfwSwitchValue` is used in handler position — now explains the RFW limitation and suggests using `RfwSwitch` to swap entire widgets
- Add documentation in README Limitations section with before/after code examples

## Context
RFW runtime only supports `setState`, `setStateFromArg`, and `event` in handler positions. Switch expressions in handlers is an architectural limitation of the RFW format, not rfw_gen.

## Test plan
- [x] All 151 expression converter tests pass
- [x] `dart analyze` clean
- [x] README examples are correct and clear

Fixes #34