### PR TITLE
chore: add skill references to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -52,3 +52,6 @@ Monorepo structure:
 - @rules/rfw-types.md: argument type encoding
 - @agents/golden-test-writer.md: golden test writing agent
 - @skills/add-golden-test.md: golden test addition skill
+- @skills/dogfood.md: dogfood DX 테스트 스킬
+- @skills/commit.md: 커밋 스킬
+- @skills/git-workflow.md: git worktree 워크플로우 스킬


### PR DESCRIPTION
## Summary
- Add @references for dogfood, commit, and git-workflow skills in CLAUDE.md
- Workaround for Claude Code 2.1.83 project-level skill discovery bug

## Context
Project-level skills in `.claude/skills/` are not auto-discovered by Claude Code. Adding `@` references in CLAUDE.md ensures they are loaded into context.