### PR TITLE
chore: add gitignore patterns and fix analyzer warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@ build/
 melos_*.iml
 .worktrees/
 example2/
+
+# rfw_gen generated files
+*.rfw_library.dart
+*.rfw_meta.json
+
+# macOS
+.DS_Store

--- a/example/test/helpers/golden_test_helper.dart
+++ b/example/test/helpers/golden_test_helper.dart
@@ -325,8 +325,8 @@ class _MockHeaders implements HttpHeaders {
   int? get port => null;
   @override
   set port(int? value) {}
-  @override
   List<String> get transferEncoding => [];
+  set transferEncoding(List<String> value) {}
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
- Add `*.rfw_library.dart`, `*.rfw_meta.json`, `.DS_Store` patterns to `.gitignore` to prevent generated files from cluttering git status
- Fix missing `transferEncoding` setter in `_MockHeaders` (golden_test_helper.dart)

## Test plan
- [x] `flutter analyze` clean on example/test/helpers/golden_test_helper.dart
- [x] Generated file patterns verified against existing untracked files

Fixes #38, Fixes #39