### PR TITLE
docs: fix rfw_preview README to match actual API

### DIFF
--- a/packages/rfw_preview/README.md
+++ b/packages/rfw_preview/README.md
@@ -6,7 +6,7 @@ and custom widget support.
 
 ## Features
 
-- **RfwPreview** — drop-in widget that renders rfwtxt from strings, files, or assets
+- **RfwPreview** — drop-in widget that renders rfwtxt from strings, binary assets, or raw bytes
 - **RfwEditorApp** — standalone editor with live preview, snippet storage, and device frames
 - **RfwEditor** — embeddable editor widget for integration into existing apps
 - **RfwEditorController** — state management for editor instances
@@ -26,20 +26,28 @@ dev_dependencies:
 import 'package:rfw_preview/rfw_preview.dart';
 
 RfwPreview(
-  source: RfwSource.text('''
+  source: RfwSource.text(
+    '''
     import core.widgets;
     widget root = Center(child: Text(text: "Hello, RFW!"));
-  '''),
+    ''',
+    library: LibraryName(['main']),
+  ),
+  widget: 'root',
 )
 ```
 
-Load from a generated `.rfwtxt` file:
+Load from a `.rfw` binary asset:
 
 ```dart
 RfwPreview(
-  source: RfwSource.file('path/to/widget.rfwtxt'),
+  source: RfwSource.asset(
+    'assets/greeting.rfw',
+    library: LibraryName(['main']),
+  ),
+  widget: 'greeting',
   data: {'user': {'name': 'Alice'}},
-  localWidgetBuilders: myCustomBuilders,
+  localWidgetLibraries: myCustomWidgetLibraries,
 )
 ```
 
@@ -49,18 +57,15 @@ Launch a full-screen editor with live preview:
 
 ```dart
 RfwEditorApp(
-  localWidgetBuilders: myCustomBuilders,
+  localWidgetLibraries: myCustomWidgetLibraries,
 )
 ```
 
 ### RfwEditor (Embeddable)
 
 ```dart
-final controller = RfwEditorController();
-
 RfwEditor(
-  controller: controller,
-  localWidgetBuilders: myCustomBuilders,
+  localWidgetLibraries: myCustomWidgetLibraries,
 )
 ```
 


### PR DESCRIPTION
## Summary
- Replace non-existent `RfwSource.file()` with `RfwSource.asset()` in examples
- Add required `widget` and `library` parameters to all `RfwPreview` examples
- Fix param name: `localWidgetBuilders` → `localWidgetLibraries`
- Remove non-existent `controller` param from `RfwEditor` example
- Update feature description to match actual source types (strings, binary assets, raw bytes)

Fixes #48
Fixes #49

## Test plan
- [x] All existing tests pass (`melos exec -- dart test`)
- [ ] Verify README examples compile correctly in a fresh project