### PR TITLE
feat: add fitness/health/timer icons to RfwIcon

### DIFF
--- a/packages/rfw_gen/lib/src/rfw_icons.dart
+++ b/packages/rfw_gen/lib/src/rfw_icons.dart
@@ -188,6 +188,17 @@ class RfwIcon {
   static const int directions = 0xe1c4;
   static const int navigation = 0xe41d;
 
+  // --- Fitness & Health ---
+  static const int fitnessCenter = 0xe28d;
+  static const int timer = 0xe662;
+  static const int directionsRun = 0xe1dc;
+  static const int localFireDepartment = 0xe392;
+  static const int schedule = 0xe556;
+  static const int trendingUp = 0xe67f;
+  static const int emojiEvents = 0xe22c;
+  static const int selfImprovement = 0xe56f;
+  static const int monitorHeart = 0xf053d;
+
   // --- Toggle ---
   static const int toggleOn = 0xe620;
   static const int toggleOff = 0xe621;
@@ -281,6 +292,13 @@ class RfwIcon {
     'place': place, 'map': map, 'myLocation': myLocation,
     'locationOn': locationOn, 'locationOff': locationOff,
     'directions': directions, 'navigation': navigation,
+
+    // Fitness & Health
+    'fitnessCenter': fitnessCenter, 'timer': timer,
+    'directionsRun': directionsRun,
+    'localFireDepartment': localFireDepartment, 'schedule': schedule,
+    'trendingUp': trendingUp, 'emojiEvents': emojiEvents,
+    'selfImprovement': selfImprovement, 'monitorHeart': monitorHeart,
 
     // Toggle
     'toggleOn': toggleOn, 'toggleOff': toggleOff,

--- a/packages/rfw_gen_builder/test/expression_converter_test.dart
+++ b/packages/rfw_gen_builder/test/expression_converter_test.dart
@@ -567,6 +567,29 @@ void main() {
       expect(map.entries['icon'], isA<IrIntValue>());
     });
 
+    test('converts fitness icons (RfwIcon.fitnessCenter, timer, etc.)', () {
+      for (final name in [
+        'fitnessCenter',
+        'timer',
+        'directionsRun',
+        'localFireDepartment',
+        'schedule',
+        'trendingUp',
+        'emojiEvents',
+        'selfImprovement',
+        'monitorHeart',
+      ]) {
+        final expr = parseExpression('RfwIcon.$name');
+        final result = converter.convert(expr);
+        expect(result, isA<IrMapValue>(), reason: 'RfwIcon.$name');
+        final map = result as IrMapValue;
+        expect(map.entries['icon'], isA<IrIntValue>(),
+            reason: 'RfwIcon.$name icon');
+        expect(map.entries['fontFamily'], isA<IrStringValue>(),
+            reason: 'RfwIcon.$name fontFamily');
+      }
+    });
+
     test('throws for unknown RfwIcon', () {
       final expr = parseExpression('RfwIcon.nonExistentIcon');
       expect(() => converter.convert(expr),


### PR DESCRIPTION
## Summary
- Add 9 new icons to `RfwIcon` for fitness/health app use cases
- Icons: `fitnessCenter`, `timer`, `directionsRun`, `localFireDepartment`, `schedule`, `trendingUp`, `emojiEvents`, `selfImprovement`, `monitorHeart`
- All codepoints verified against Flutter SDK 3.35.1
- Add test covering all new icons

Fixes #53

## Test plan
- [x] All existing tests pass (563 total, +1 new)
- [x] New test verifies all 9 icons convert to valid `IrMapValue` with `icon` and `fontFamily`