### PR TITLE
feat: add RfwSource.file() for dev-time rfwtxt loading

### DIFF
--- a/packages/rfw_preview/lib/src/rfw_preview_widget.dart
+++ b/packages/rfw_preview/lib/src/rfw_preview_widget.dart
@@ -164,6 +164,11 @@ class _RfwPreviewState extends State<RfwPreview> {
             source.library,
             decodeLibraryBlob(source.bytes),
           );
+        case RfwFileSource():
+          _runtime.update(
+            source.library,
+            parseLibraryFile(source.readAsString()),
+          );
       }
       if (mounted) {
         setState(() => _isLoaded = true);

--- a/packages/rfw_preview/lib/src/rfw_source.dart
+++ b/packages/rfw_preview/lib/src/rfw_source.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:rfw/rfw.dart';
@@ -5,7 +6,7 @@ import 'package:rfw/rfw.dart';
 /// Source for RFW widget library data.
 ///
 /// Defines how to load the widget library — from an asset bundle,
-/// an rfwtxt string, or raw binary bytes.
+/// an rfwtxt string, a local file, or raw binary bytes.
 sealed class RfwSource {
   const RfwSource({required this.library});
 
@@ -52,6 +53,23 @@ sealed class RfwSource {
     Uint8List bytes, {
     required LibraryName library,
   }) = RfwBinarySource;
+
+  /// Load from a local `.rfwtxt` file on disk.
+  ///
+  /// Reads the file as a UTF-8 string and parses it as rfwtxt.
+  /// Useful during development to preview generated `.rfwtxt` files
+  /// without adding them to the asset bundle.
+  ///
+  /// ```dart
+  /// RfwSource.file(
+  ///   'lib/widgets.rfwtxt',
+  ///   library: LibraryName(['main']),
+  /// )
+  /// ```
+  const factory RfwSource.file(
+    String path, {
+    required LibraryName library,
+  }) = RfwFileSource;
 }
 
 /// Loads RFW library from a `.rfw` binary asset.
@@ -76,4 +94,15 @@ final class RfwBinarySource extends RfwSource {
 
   /// The raw `.rfw` binary data.
   final Uint8List bytes;
+}
+
+/// Loads RFW library from a local `.rfwtxt` file.
+final class RfwFileSource extends RfwSource {
+  const RfwFileSource(this.path, {required super.library});
+
+  /// File path to a `.rfwtxt` file (e.g., `'lib/widgets.rfwtxt'`).
+  final String path;
+
+  /// Reads the file content synchronously.
+  String readAsString() => File(path).readAsStringSync();
 }

--- a/packages/rfw_preview/test/rfw_source_test.dart
+++ b/packages/rfw_preview/test/rfw_source_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rfw/rfw.dart';
+import 'package:rfw_preview/rfw_preview.dart';
+
+void main() {
+  group('RfwFileSource', () {
+    late File tempFile;
+
+    setUp(() {
+      tempFile = File('${Directory.systemTemp.path}/test_widget.rfwtxt');
+      tempFile.writeAsStringSync('''
+import core.widgets;
+widget testWidget = Center(child: Text(text: "Hello from file"));
+''');
+    });
+
+    tearDown(() {
+      if (tempFile.existsSync()) tempFile.deleteSync();
+    });
+
+    test('stores path and library', () {
+      final source = RfwSource.file(
+        tempFile.path,
+        library: const LibraryName(['test']),
+      );
+      expect(source, isA<RfwFileSource>());
+      final fileSource = source as RfwFileSource;
+      expect(fileSource.path, tempFile.path);
+      expect(fileSource.library, const LibraryName(['test']));
+    });
+
+    test('readAsString returns file content', () {
+      final source = RfwFileSource(
+        tempFile.path,
+        library: const LibraryName(['test']),
+      );
+      final content = source.readAsString();
+      expect(content, contains('testWidget'));
+      expect(content, contains('Hello from file'));
+    });
+
+    test('readAsString throws on missing file', () {
+      final source = RfwFileSource(
+        '/nonexistent/path.rfwtxt',
+        library: const LibraryName(['test']),
+      );
+      expect(() => source.readAsString(), throwsA(isA<FileSystemException>()));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `RfwSource.file()` constructor to `RfwSource` sealed class
- Enables loading `.rfwtxt` files directly from disk during development
- No asset bundle configuration needed — just point to the generated file path
- Handles the `RfwFileSource` case in `RfwPreview._loadSource()`

```dart
RfwPreview(
  source: RfwSource.file(
    'lib/widgets.rfwtxt',
    library: LibraryName(['main']),
  ),
  widget: 'myWidget',
)
```

Fixes #52

## Test plan
- [x] All existing tests pass
- [x] New unit tests for `RfwFileSource`: path/library storage, file reading, missing file error