### PR TITLE
release: v0.5.0

### DIFF
--- a/packages/rfw_gen/CHANGELOG.md
+++ b/packages/rfw_gen/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.0
+
+- Add fitness/health/timer category icons to `RfwIcon` (fitnessCenter, timer, directionsRun, etc.)
+- Add setState toggle pattern example to README
+- Add rfw dependency and rendering guide to README
+
 ## 0.4.1
 
 - No changes (version bump to match rfw_gen_builder)

--- a/packages/rfw_gen/pubspec.yaml
+++ b/packages/rfw_gen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen
 description: Annotations and runtime helpers for converting Flutter Widget code to RFW (Remote Flutter Widgets) format.
-version: 0.4.1
+version: 0.5.0
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:

--- a/packages/rfw_gen_builder/CHANGELOG.md
+++ b/packages/rfw_gen_builder/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.5.0
+
+- Fix: handle `Icons.xxx` expressions by converting to iconData map (#41)
+- Fix: handle `double.infinity` with actionable error message (#41)
+- Fix: translate Korean warning/error messages to English (#42)
+- Fix: skip `.rfw_library.dart` and `.rfw_meta.json` generation for files without `@RfwWidget` (#42)
+- Fix: improve handler error message and document RfwSwitch limitation (#44)
+
 ## 0.4.1
 
 - Fix: use `show` directive in generated `.rfw_library.dart` imports to prevent name conflicts with Flutter built-in widgets (#23)

--- a/packages/rfw_gen_builder/pubspec.yaml
+++ b/packages/rfw_gen_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen_builder
 description: build_runner code generator for rfw_gen. Converts @RfwWidget-annotated Flutter functions to RFW format.
-version: 0.4.1
+version: 0.5.0
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:
@@ -18,7 +18,7 @@ dependencies:
   analyzer: ">=9.0.0 <13.0.0"
   build: ^4.0.0
   rfw: ^1.0.0
-  rfw_gen: ^0.4.0
+  rfw_gen: ^0.5.0
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/packages/rfw_gen_mcp/CHANGELOG.md
+++ b/packages/rfw_gen_mcp/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0
+
+- No changes (version bump to match rfw_gen ecosystem)
+
 ## 0.4.1
 
 - No changes (version bump to match rfw_gen_builder)

--- a/packages/rfw_gen_mcp/pubspec.yaml
+++ b/packages/rfw_gen_mcp/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_gen_mcp
 description: MCP server exposing rfw_gen widget registry, code conversion, and rfwtxt validation.
-version: 0.4.1
+version: 0.5.0
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:
@@ -20,8 +20,8 @@ resolution: workspace
 dependencies:
   mcp_dart: ^2.0.0
   rfw: ^1.0.0
-  rfw_gen: ^0.4.0
-  rfw_gen_builder: ^0.4.0
+  rfw_gen: ^0.5.0
+  rfw_gen_builder: ^0.5.0
 
 dev_dependencies:
   lints: ^5.0.0

--- a/packages/rfw_preview/CHANGELOG.md
+++ b/packages/rfw_preview/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.0
+
+- Fix: README Quick Start examples now include required `widget` and `library` parameters (#49)
+- Fix: replace non-existent `RfwSource.file()` with `RfwSource.asset()` in README (#48)
+- Add unit tests for core preview logic (#47)
+
 ## 0.4.1
 
 - No changes (version bump to match rfw_gen_builder)

--- a/packages/rfw_preview/pubspec.yaml
+++ b/packages/rfw_preview/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rfw_preview
 description: Dev preview widget for rfw_gen. Renders generated rfwtxt with automatic Runtime setup and custom widget support.
-version: 0.4.1
+version: 0.5.0
 homepage: https://github.com/BottlePumpkin/rfw_gen
 repository: https://github.com/BottlePumpkin/rfw_gen
 


### PR DESCRIPTION
## Summary
Release v0.5.0 — version bump + CHANGELOG update for all 4 packages.

### Changes since v0.4.1

**rfw_gen**
- Add fitness/health/timer category icons to `RfwIcon`
- Add setState toggle pattern example to README
- Add rfw dependency and rendering guide to README

**rfw_gen_builder**
- Fix `Icons.xxx` and `double.infinity` expression handling (#41)
- Translate Korean warning/error messages to English (#42)
- Skip empty file generation for files without `@RfwWidget` (#42)
- Improve handler error message and document RfwSwitch limitation (#44)

**rfw_preview**
- Fix README Quick Start: add required `widget` and `library` params (#49)
- Replace non-existent `RfwSource.file()` with `RfwSource.asset()` in README (#48)
- Add unit tests for core preview logic (#47)

**rfw_gen_mcp**
- Version bump to match ecosystem

## Test plan
- [x] `melos exec -- dart test` — all 563+ tests pass
- [ ] Verify CHANGELOG entries are accurate
- [ ] Tag `v0.5.0` after merge