### PR TITLE
release: 0.5.1 — update homepage to GitHub Pages playground

### DIFF
--- a/packages/rfw_gen/CHANGELOG.md
+++ b/packages/rfw_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+- Update homepage to GitHub Pages playground
+
 ## 0.5.0
 
 - Add fitness/health/timer category icons to `RfwIcon` (fitnessCenter, timer, directionsRun, etc.)

--- a/packages/rfw_gen/pubspec.yaml
+++ b/packages/rfw_gen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: rfw_gen
 description: Annotations and runtime helpers for converting Flutter Widget code to RFW (Remote Flutter Widgets) format.
-version: 0.5.0
-homepage: https://github.com/BottlePumpkin/rfw_gen
+version: 0.5.1
+homepage: https://bottlepumpkin.github.io/rfw_gen/
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:
   - rfw

--- a/packages/rfw_gen_builder/CHANGELOG.md
+++ b/packages/rfw_gen_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+- Update homepage to GitHub Pages playground
+
 ## 0.5.0
 
 - Fix: handle `Icons.xxx` expressions by converting to iconData map (#41)

--- a/packages/rfw_gen_builder/pubspec.yaml
+++ b/packages/rfw_gen_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: rfw_gen_builder
 description: build_runner code generator for rfw_gen. Converts @RfwWidget-annotated Flutter functions to RFW format.
-version: 0.5.0
-homepage: https://github.com/BottlePumpkin/rfw_gen
+version: 0.5.1
+homepage: https://bottlepumpkin.github.io/rfw_gen/
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:
   - rfw

--- a/packages/rfw_gen_mcp/CHANGELOG.md
+++ b/packages/rfw_gen_mcp/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+- Update homepage to GitHub Pages playground
+
 ## 0.5.0
 
 - No changes (version bump to match rfw_gen ecosystem)

--- a/packages/rfw_gen_mcp/pubspec.yaml
+++ b/packages/rfw_gen_mcp/pubspec.yaml
@@ -1,7 +1,7 @@
 name: rfw_gen_mcp
 description: MCP server exposing rfw_gen widget registry, code conversion, and rfwtxt validation.
-version: 0.5.0
-homepage: https://github.com/BottlePumpkin/rfw_gen
+version: 0.5.1
+homepage: https://bottlepumpkin.github.io/rfw_gen/
 repository: https://github.com/BottlePumpkin/rfw_gen
 topics:
   - rfw

--- a/packages/rfw_preview/CHANGELOG.md
+++ b/packages/rfw_preview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+- Update homepage to GitHub Pages playground
+
 ## 0.5.0
 
 - Fix: README Quick Start examples now include required `widget` and `library` parameters (#49)

--- a/packages/rfw_preview/pubspec.yaml
+++ b/packages/rfw_preview/pubspec.yaml
@@ -1,7 +1,7 @@
 name: rfw_preview
 description: Dev preview widget for rfw_gen. Renders generated rfwtxt with automatic Runtime setup and custom widget support.
-version: 0.5.0
-homepage: https://github.com/BottlePumpkin/rfw_gen
+version: 0.5.1
+homepage: https://bottlepumpkin.github.io/rfw_gen/
 repository: https://github.com/BottlePumpkin/rfw_gen
 
 environment:


### PR DESCRIPTION
## Summary

- 4개 패키지 homepage를 GitHub Pages playground URL로 변경
  - `https://github.com/BottlePumpkin/rfw_gen` → `https://bottlepumpkin.github.io/rfw_gen/`
- Version bump: 0.5.0 → 0.5.1

## Packages

- rfw_gen: 0.5.1
- rfw_gen_builder: 0.5.1
- rfw_gen_mcp: 0.5.1
- rfw_preview: 0.5.1

## Test plan

- [ ] `melos exec -- dart test` passes
- [ ] pub.dev publish dry-run succeeds